### PR TITLE
Add some more signed xpi (signed xpi added to mozilla-central as unpacked)

### DIFF
--- a/unpacked/regular/browser_dragdrop1/manifest.json
+++ b/unpacked/regular/browser_dragdrop1/manifest.json
@@ -1,0 +1,12 @@
+{
+  "manifest_version": 2,
+
+  "browser_specific_settings": {
+    "gecko": {
+      "id": "dragdrop-1@tests.mozilla.org"
+    }
+  },
+
+  "name": "Drag Drop test 1",
+  "version": "1.0"
+}

--- a/unpacked/regular/browser_dragdrop1/manifest.json
+++ b/unpacked/regular/browser_dragdrop1/manifest.json
@@ -1,12 +1,10 @@
 {
   "manifest_version": 2,
-
   "browser_specific_settings": {
     "gecko": {
       "id": "dragdrop-1@tests.mozilla.org"
     }
   },
-
   "name": "Drag Drop test 1",
   "version": "1.0"
 }

--- a/unpacked/regular/browser_dragdrop2/manifest.json
+++ b/unpacked/regular/browser_dragdrop2/manifest.json
@@ -1,0 +1,12 @@
+{
+  "manifest_version": 2,
+
+  "browser_specific_settings": {
+    "gecko": {
+      "id": "dragdrop-2@tests.mozilla.org"
+    }
+  },
+
+  "name": "Drag Drop test 2",
+  "version": "1.1"
+}

--- a/unpacked/regular/browser_dragdrop2/manifest.json
+++ b/unpacked/regular/browser_dragdrop2/manifest.json
@@ -1,12 +1,10 @@
 {
   "manifest_version": 2,
-
   "browser_specific_settings": {
     "gecko": {
       "id": "dragdrop-2@tests.mozilla.org"
     }
   },
-
   "name": "Drag Drop test 2",
   "version": "1.1"
 }

--- a/unpacked/regular/browser_dragdrop_incompat/manifest.json
+++ b/unpacked/regular/browser_dragdrop_incompat/manifest.json
@@ -1,0 +1,13 @@
+{
+  "manifest_version": 2,
+
+  "browser_specific_settings": {
+    "gecko": {
+      "id": "dragdrop-incompat@tests.mozilla.org",
+      "strict_max_version": "45.0"
+    }
+  },
+
+  "name": "Incomatible Drag Drop test",
+  "version": "1.1"
+}

--- a/unpacked/regular/browser_dragdrop_incompat/manifest.json
+++ b/unpacked/regular/browser_dragdrop_incompat/manifest.json
@@ -1,13 +1,11 @@
 {
   "manifest_version": 2,
-
   "browser_specific_settings": {
     "gecko": {
       "id": "dragdrop-incompat@tests.mozilla.org",
       "strict_max_version": "45.0"
     }
   },
-
   "name": "Incomatible Drag Drop test",
   "version": "1.1"
 }

--- a/unpacked/regular/browser_installssl/manifest.json
+++ b/unpacked/regular/browser_installssl/manifest.json
@@ -1,0 +1,12 @@
+{
+  "manifest_version": 2,
+
+  "browser_specific_settings": {
+    "gecko": {
+      "id": "sslinstall-1@tests.mozilla.org"
+    }
+  },
+
+  "name": "SSL Install Tests",
+  "version": "1.0"
+}

--- a/unpacked/regular/browser_installssl/manifest.json
+++ b/unpacked/regular/browser_installssl/manifest.json
@@ -1,12 +1,10 @@
 {
   "manifest_version": 2,
-
   "browser_specific_settings": {
     "gecko": {
       "id": "sslinstall-1@tests.mozilla.org"
     }
   },
-
   "name": "SSL Install Tests",
   "version": "1.0"
 }

--- a/unpacked/regular/options_signed/manifest.json
+++ b/unpacked/regular/options_signed/manifest.json
@@ -1,0 +1,11 @@
+{
+  "manifest_version": 2,
+
+  "name": "Test options_ui",
+  "description": "Test add-ons manager handling options_ui with no id in manifest.json",
+  "version": "1.2",
+
+  "options_ui": {
+    "page": "options.html"
+  }
+}

--- a/unpacked/regular/options_signed/manifest.json
+++ b/unpacked/regular/options_signed/manifest.json
@@ -1,10 +1,8 @@
 {
   "manifest_version": 2,
-
   "name": "Test options_ui",
   "description": "Test add-ons manager handling options_ui with no id in manifest.json",
   "version": "1.2",
-
   "options_ui": {
     "page": "options.html"
   }

--- a/unpacked/regular/options_signed/options.html
+++ b/unpacked/regular/options_signed/options.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+  </head>
+  <body>
+    <div id="options-test-panel" />
+  </body>
+</html>

--- a/unpacked/regular/signed-webext/manifest.json
+++ b/unpacked/regular/signed-webext/manifest.json
@@ -1,0 +1,12 @@
+{
+  "manifest_version": 2,
+  "name": "XPI Telemetry Signed Test",
+  "description": "A signed webextension",
+  "version": "1.0",
+
+  "applications": {
+    "gecko": {
+      "id": "tel-signed-webext@tests.mozilla.org"
+    }
+  }
+}

--- a/unpacked/regular/signed-webext/manifest.json
+++ b/unpacked/regular/signed-webext/manifest.json
@@ -3,8 +3,7 @@
   "name": "XPI Telemetry Signed Test",
   "description": "A signed webextension",
   "version": "1.0",
-
-  "applications": {
+  "browser_specific_settings": {
     "gecko": {
       "id": "tel-signed-webext@tests.mozilla.org"
     }


### PR DESCRIPTION
This PR includes the additional manifest.json file that need to be signed with the AMO production signature, but they were missing from the original scan because they are unpacked in mozilla-central and packed into a signed xpi file when the test suite using those test extension is executed (e.g. `mach mochitest toolkit/mozapps/extensions/test/browser/browser_installssl.js`).