### PR TITLE
Added amosigned and amosigned-mv3 test extensions

### DIFF
--- a/unpacked/regular/amosigned-mv3/manifest.json
+++ b/unpacked/regular/amosigned-mv3/manifest.json
@@ -1,0 +1,10 @@
+{
+  "manifest_version": 3,
+  "browser_specific_settings": {
+    "gecko": {
+      "id": "amosigned-mv3-xpi@tests.mozilla.org"
+    }
+  },
+  "name": "XPI Test",
+  "version": "3.1"
+}

--- a/unpacked/regular/amosigned/manifest.json
+++ b/unpacked/regular/amosigned/manifest.json
@@ -1,0 +1,10 @@
+{
+  "manifest_version": 2,
+  "browser_specific_settings": {
+    "gecko": {
+      "id": "amosigned-xpi@tests.mozilla.org"
+    }
+  },
+  "name": "XPI Test",
+  "version": "2.1"
+}


### PR DESCRIPTION
This PR includes two more test extensions:
- amosigned: we need this one resigned (because we will need one with old and new signatures for some tests I'd like to add)
- amosigned-mv3: we don't need this to be resigned, but to keep it along with the others in this repo